### PR TITLE
Adding complex test with a mix of different actions

### DIFF
--- a/tests/testCryptoAvisosV1.js
+++ b/tests/testCryptoAvisosV1.js
@@ -440,8 +440,8 @@ describe("CryptoAvisosV1", function () {
         let daiBalanceContractAfterRefund = ethers.utils.formatUnits(await this.dai.balanceOf(this.cryptoAvisosV1.address));
 
         // Assert balances after claim fees of released tickets
-        expect(Number(daiBalanceBuyerAfterPayment)).equal(Number(daiBalanceBuyerBeforePayment) + Number(ethers.utils.formatUnits(product5.price)));
-        expect(Number(daiBalanceContractAfterPayment)).equal(Number(daiBalanceContractBeforePayment) - Number(ethers.utils.formatUnits(product5.price)));
+        expect(Number(daiBalanceBuyerAfterRefund)).equal(Number(daiBalanceBuyerBeforeRefund) + Number(ethers.utils.formatUnits(product5.price)));
+        expect(Number(daiBalanceContractAfterRefund)).equal(Number(daiBalanceContractBeforeRefund) - Number(ethers.utils.formatUnits(product5.price)));
 
     });
 


### PR DESCRIPTION
Test flow:

1. User pay for 2 products in DAI, 2 tickets are created.
2. Owner release 1 ticket, the other is still WAITING.
3. Owner call available fees and claim what is returned by the function.
4. Owner refund the WAITING ticket.

Expected behavior:
After the last refund, the buyer should receive the amount paid by the product (no fees should be charged)

Actual behavior:
The refund call to the contract fails with "ERC20: transfer amount exceeds balance". 

The problem on this is that we sum the fees charged to the seller in payProduct function. So this fee amount is available to claim right after the ticket is created in WAITING status.

I found a possible fix to this that will push in another pull request.

