### PR TITLE
Refactor fee accum

### DIFF
--- a/contracts/CryptoAvisosV1.sol
+++ b/contracts/CryptoAvisosV1.sol
@@ -209,7 +209,6 @@ contract CryptoAvisosV1 is Ownable {
         }
 
         uint toFee = product.price * fee / 100e18;
-        claimableFee[product.token] += toFee;
 
         //Create ticket
         uint ticketId = uint(keccak256(abi.encode(productId, msg.sender, block.number, product.stock)));
@@ -238,6 +237,8 @@ contract CryptoAvisosV1 is Ownable {
             //Pay with token
             IERC20(ticket.tokenPaid).transfer(product.seller, finalPrice);
         }
+
+        claimableFee[product.token] += ticket.feeCharged;
 
         ticket.status = Status.SOLD;
         productTicketsMapping[ticketId] = ticket;
@@ -278,7 +279,6 @@ contract CryptoAvisosV1 is Ownable {
             //ERC20
             IERC20(ticket.tokenPaid).transfer(ticket.buyer, ticket.pricePaid);
         }
-        claimableFee[ticket.tokenPaid] -= ticket.feeCharged;
         ticket.status = Status.SOLD;
         
         productTicketsMapping[ticketId] = ticket;

--- a/tests/testCryptoAvisosV1.js
+++ b/tests/testCryptoAvisosV1.js
@@ -155,8 +155,9 @@ describe("CryptoAvisosV1", function () {
         expect(Number(daiBalanceContractAfter)).equal(Number(daiBalanceContractBefore) + Number(ethers.utils.formatUnits(product.price)));
         expect(Number(product.stock)).equal(Number(stockBefore) - 1);
 
+        // Fee to claim after pay should be zero
         let claimableFee = await this.cryptoAvisosV1.claimableFee(productBefore.token);
-        expect(Number(claimableFee)).equal(Number(productBefore.price * fee / 100));
+        expect(Number(claimableFee)).equal(0);
 
         let latestBlock = await ethers.provider.getBlock("latest");
         let ticketIdTest = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode([ "uint", "address", "uint", "uint" ], [productArray[0], buyer.address, latestBlock.number, stockBefore]));
@@ -192,8 +193,9 @@ describe("CryptoAvisosV1", function () {
         expect(Number(ethBalanceContractAfter)).equal(Number(ethBalanceContractBefore) + Number(ethers.utils.formatUnits(productAfter.price)));
         expect(Number(productAfter.stock)).equal(Number(stockBefore) - 1);
 
+        // Fee to claim after pay should be zero
         let claimableFee = await this.cryptoAvisosV1.claimableFee(productBefore.token);
-        expect(Number(claimableFee)).equal(Number(productBefore.price * fee / 100));
+        expect(Number(claimableFee)).equal(0);
 
         let latestBlock = await ethers.provider.getBlock("latest");
         ticketIdTest = ethers.utils.keccak256(ethers.utils.defaultAbiCoder.encode([ "uint", "address", "uint", "uint" ], [productArray[1], buyer.address, latestBlock.number, stockBefore]));
@@ -226,6 +228,10 @@ describe("CryptoAvisosV1", function () {
 
         let ticket = await this.cryptoAvisosV1.productTicketsMapping(ticketToRelease[0]);
         expect(ticket.status).equal(1); // SOLD
+
+        // Fee to claim added after release (can't be refunded)
+        let claimableFee = await this.cryptoAvisosV1.claimableFee(ticket.tokenPaid);
+        expect(Number(claimableFee)).equal(Number(ticket.pricePaid * fee / 100));
     });
 
     it("Should release ETH from product pay...", async function () {
@@ -246,6 +252,10 @@ describe("CryptoAvisosV1", function () {
 
         let ticket = await this.cryptoAvisosV1.productTicketsMapping(ticketToRelease[0]);
         expect(ticket.status).equal(1); // SOLD
+
+        // Fee to claim added after release (can't be refunded)
+        let claimableFee = await this.cryptoAvisosV1.claimableFee(ticket.tokenPaid);
+        expect(Number(claimableFee)).equal(Number(ticket.pricePaid * fee / 100));
     });
 
     it("Should refund a product in DAI...", async function () {


### PR DESCRIPTION
Test flow:

User pay for 2 products in DAI, 2 tickets are created.
Owner release 1 ticket, the other is still WAITING.
Owner call available fees and claim what is returned by the function.
Owner refund the WAITING ticket.

Expected behavior:
After the last refund, the buyer should receive the amount paid by the product (no fees should be charged)

Actual behavior:
The refund call to the contract fails with "ERC20: transfer amount exceeds balance".

The problem on this is that we sum the fees charged to the seller in payProduct function. So this fee amount is available to claim right after the ticket is created in WAITING status.

Moving the sum of the claimable fees to the release method should fix this problem, since at this point the seller already receives the price paid by the buyer - fees calculated

